### PR TITLE
Check if header is already a Block instance in transform

### DIFF
--- a/src/protocolTransforms.js
+++ b/src/protocolTransforms.js
@@ -42,7 +42,7 @@ var toTransaction = (raw) => {
   }
   return tx
 }
-var toHeader = (header) => assign(new Block(), header)
+var toHeader = (header) => header.getHash ? header : assign(new Block(), header)
 
 var encodeTransforms = {
   'tx': fromTransaction,


### PR DESCRIPTION
When overriding the header type in bitcoin-protocol, it's possible messages already contain Block instances (or a subclass thereof).

For [webcoin-dogecoin](https://github.com/stephank/webcoin-dogecoin), I'm actually implementing the abstract-encoding interface in a Block subclass, so that I can parse the optional auxpow data found in headers.